### PR TITLE
add _logs directory so tests won't fail on directory not existing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 __*
-_logs/*
+_logs/*.log
 *.log
 node_modules
 node_modules/*


### PR DESCRIPTION
Pulled down the project to play around with and running the test failed because the logs directory did not exist. Updated the .gitignore file and added a .gitkeep to check in the folder but not the log files.
